### PR TITLE
Update setup.py - Unpin opentracing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     platforms='any',
     install_requires=[
         'tornado',
-        'opentracing==2.0.0',
+        'opentracing',
         'wrapt',
     ],
     extras_require={


### PR DESCRIPTION
Unpin opentracing, due to Jaeger python client incompatibility with Opentracing v2.