### PR TITLE
Unlock OT 2.0.0 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     platforms='any',
     install_requires=[
         'tornado',
-        'opentracing==2.0.0',
+        'opentracing>=2.0,<2.1',
         'wrapt',
     ],
     extras_require={


### PR DESCRIPTION
The current opentracing dependency is hardcoded for 2.0.0, which will prevent pulling in future stable version updates and conflicts with development branch installations.